### PR TITLE
Relocate IridiumCore dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,9 +66,21 @@ tasks {
         archiveClassifier.set("")
 
         // Relocate dependencies
+        relocate("com.iridium.iridiumcolorapi")
+        relocate("com.iridium.iridiumcore")
         relocate("com.j256.ormlite")
-        relocate("org.bstats")
         relocate("de.jeff_media")
+        relocate("org.bstats")
+
+        // Relocate IridiumCore dependencies
+        relocate("com.cryptomorin.xseries")
+        relocate("com.fasterxml.jackson")
+        relocate("de.tr7zw.changeme.nbtapi")
+        relocate("io.papermc")
+        relocate("org.apache.commons")
+        relocate("org.intellij")
+        relocate("org.jetbrains")
+        relocate("org.yaml.snakeyaml")
 
         // Remove unnecessary files from the jar
         minimize()


### PR DESCRIPTION
Due to the changes to the relocation in IridiumCore, these need to be relocated by IridiumEnchants